### PR TITLE
Implement attrs extraction for the reference labels

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -20,7 +20,7 @@
     "related_identifiers": [
         {
             "scheme": "url",
-            "identifier": "https://github.com/coreofscience/python-wostools/tree/v1.0.1",
+            "identifier": "https://github.com/coreofscience/python-wostools/tree/v1.1.0",
             "relation": "isSupplementTo"
         },
         {

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.1
+current_version = 1.1.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/coreofscience/python-wostools",
-    version="1.0.1",
+    version="1.1.0",
     zip_safe=False,
 )

--- a/tests/test_wostools.py
+++ b/tests/test_wostools.py
@@ -90,7 +90,7 @@ def test_aliases(article):
         with pytest.raises(AttributeError):
             article.CR
     if hasattr(article, "CR"):
-        assert article.CR == article.references
+        assert article.CR == [ref.label for ref in article.references]
     else:
         with pytest.raises(AttributeError):
             article.CR

--- a/tests/test_wostools.py
+++ b/tests/test_wostools.py
@@ -90,7 +90,7 @@ def test_aliases(article):
         with pytest.raises(AttributeError):
             article.CR
     if hasattr(article, "CR"):
-        assert article.CR == [ref.label for ref in article.references]
+        assert article.CR == article.references
     else:
         with pytest.raises(AttributeError):
             article.CR

--- a/wostools/__init__.py
+++ b/wostools/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Core of Science"""
 __email__ = "dev@coreofscience.com"
-__version__ = "1.0.1"
+__version__ = "1.1.0"
 
 from wostools.wostools import CollectionLazy, WosToolsError, Article
 

--- a/wostools/wostools.py
+++ b/wostools/wostools.py
@@ -27,6 +27,7 @@ class WosToolsError(Exception):
 
     pass
 
+
 class Reference(object):
     def __init__(self, label: str):
         self._label = label
@@ -63,16 +64,12 @@ class Reference(object):
             re.X,
         )
 
-        default_value = {attr: attr is "PY" and 0 or None for attr in LABEL_ATTRIBUTES}
+        default_value = {attr: 0 if attr is "PY" else None for attr in LABEL_ATTRIBUTES}
 
         match_result = pattern.match(label)
         if match_result:
             match_dict = match_result.groupdict()
-            try:
-                match_dict["PY"] = int(match_dict["PY"])
-            except ValueError:
-                # TODO: maybe we can raise a warning about the year parsing failure
-                match_dict["PY"] = 0
+            match_dict["PY"] = int(match_dict["PY"] or 0)
             return match_dict
         else:
             # TODO: maybe we can raise a warning about the label parsing failure

--- a/wostools/wostools.py
+++ b/wostools/wostools.py
@@ -60,13 +60,19 @@ class Reference(object):
             re.X,
         )
 
-        default_value = {attr: None for attr in LABEL_ATTRIBUTES}
+        default_value = {attr: attr is "PY" and 0 or None for attr in LABEL_ATTRIBUTES}
 
         match_result = pattern.match(label)
         if match_result:
-            return match_result.groupdict()
+            match_dict = match_result.groupdict()
+            try:
+                match_dict["PY"] = int(match_dict["PY"])
+            except ValueError:
+                # TODO: maybe we can raise a warning about the year parsing failure
+                match_dict["PY"] = 0
+            return match_dict
         else:
-            # TODO: maybe we can raise a warning about the label parsing
+            # TODO: maybe we can raise a warning about the label parsing failure
             return default_value
 
 

--- a/wostools/wostools.py
+++ b/wostools/wostools.py
@@ -39,6 +39,9 @@ class Reference(object):
             )
         return self.__processed_data[name]
 
+    def __repr__(self):
+        return self._label
+
     @property
     def label_attrs(self):
         return self.__processed_data


### PR DESCRIPTION
## Description
This feature allow to access to the record attributes and labels in a similar way without take in mind if it's an article or reference.

Si... If we are gonna use this feature in `python-sap`, we can build the graph in the following way:
```python
vertices = {}
pair_labels = []
for art, ref in collection.citation_pairs(pair_parser=lambda art, ref: (art, ref)):
    vertices[art.label] = {**art.label_attrs, "_record_type": "article"}
    vertices[ref.label] = {**ref.label_attrs, "_record_type": "reference"}
    pair_labels.append((art.label, ref.label))

graph = ig.Graph(directed=True)
for label, attrs in vertices.items():
    graph.add_vertex(name=label, label=label, **attrs)

graph.add_edges(pair_labels)
```

## TODO's to finish the feature

- [ ] Add tests.
- [ ] Add docstrings.

## NOTE
_I'm not sure if it's a good solution, so, feel free to give feedback or reject the changes, this is the way to learn more_ :dancer: 